### PR TITLE
Sudo make

### DIFF
--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -44,9 +44,3 @@
   with_items:
     - 'update-alternatives --install "/usr/bin/node" "node" "/usr/local/nodejs/default/bin/node" 1'
     - 'update-alternatives --set node /usr/local/nodejs/default/bin/node'
-
-- name: node.js | Inform the system where npm is located and set this one as the default
-  shell: "{{item}}"
-  with_items:
-    - 'update-alternatives --install "/usr/bin/npm" "npm" "/usr/local/nodejs/default/bin/npm" 1'
-    - 'update-alternatives --set npm /usr/local/nodejs/default/bin/npm'


### PR DESCRIPTION
Hello,

I've noticed that nodejs is built with sudo in your role. Maybe there's a reason for it that I'm not aware of. However, since building applications using is a privileged user is a bad practice, I've tested removing it and the build runs just fine. Also, node and npm applications work as expected after build.

Is there any reason to build nodejs with sudo? If not, would you mind accepting this PR?

Thank you!
