### PR TITLE
Allow this to upgrade the node version when using package

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -12,5 +12,5 @@
 
 - name: node.js | Install the node.js package
   apt:
-    pkg: "nodejs"
+    pkg: nodejs={{nodejs_version}}
     state: present


### PR DESCRIPTION
If you already have node installed this allows you to upgrade it to whatever version you specify. It looks like the nodejs_version was only previously used for the source downloads. 
