### PR TITLE
remove build-essential dep for package install

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,5 @@ galaxy_info:
   - development
 
 dependencies:
-  - Ansibles.build-essential
+  - role: Ansibles.build-essential
+    when: nodejs_install_method is defined and nodejs_install_method == "source"


### PR DESCRIPTION
build-essential is only required when building nodejs from source
