### PR TITLE
Added binary installation option to download "binary" pre-compiled code from nodejs website

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ Ansible role for installing nodejs, from package or by building it from source.
 #### Variables
 
 ```yaml
-nodejs_install_method: "source"     # "package" or "source"
 nodejs_version: "0.10.26"           # nodejs version to install.
+nodejs_install_method: "source"     # "package" or "source" or "binary"
+```
+
+For "unstable" node versions (0.11), you may wish to use "binary" if you don't want to compile from source:
+
+```yaml
+nodejs_version: "0.11.13"           # nodejs version to install.
+nodejs_install_method: "binary"     # "source" or "binary" (package is not available for 0.11)
 ```
 
 #### Thanks to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,7 @@
 # file: nodejs/defaults/main.yml
 
-#nodejs_install_method     : "source"
-#nodejs_version            : "0.10.26"
-
-nodejs_install_method     : "binary"
-nodejs_version            : "0.11.13"
+nodejs_install_method     : "source"
+nodejs_version            : "0.10.26"
 
 nodejs_directory          : "/usr/local/nodejs"
 nodejs_source_url         : "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,15 @@
 # file: nodejs/defaults/main.yml
 
-nodejs_install_method: "source"
-nodejs_version: "0.10.26"
-nodejs_url: "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
-nodejs_prefix: "/usr/local/nodejs/node-v{{nodejs_version}}"
+#nodejs_install_method     : "source"
+#nodejs_version            : "0.10.26"
+
+nodejs_install_method     : "binary"
+nodejs_version            : "0.11.13"
+
+nodejs_directory          : "/usr/local/nodejs"
+nodejs_source_url         : "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
+nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
+
+# possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
+nodejs_binary_url         : "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
+nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@
 galaxy_info:
   author: pjan vandaele
   company: ANXS
-  description: "Install nodejs, from package or build from source"
+  description: "Install nodejs, from package, build from source or download binary tarball"
   min_ansible_version: 1.4
   license: MIT
   platforms:

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -1,0 +1,26 @@
+# file: nodejs/tasks/binary.yml
+
+- name: node.js | binary | Make sure that the directory to hold the node.js binaries exists
+  file:
+    path: "{{nodejs_binary_prefix}}"
+    state: directory
+    recurse: yes
+    mode: 0755
+
+- name: node.js | binary | Download the node.js binary for your distribution
+  get_url:
+    url: "{{nodejs_binary_url}}"
+    dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
+
+- name: node.js | binary | Unpack the node.js package
+  unarchive: src="/tmp/node-v{{nodejs_version}}.tar.gz" dest="/usr/local/nodejs" copy=no
+
+- name: node.js | binary | Update the symbolic link to the node.js install
+  file:
+    path: "{{nodejs_directory}}/default"
+    src: "{{nodejs_binary_prefix}}"
+    state: link
+    force: yes
+
+- include: update_path.yml
+

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -13,7 +13,10 @@
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
 - name: node.js | binary | Unpack the node.js package
-  unarchive: src="/tmp/node-v{{nodejs_version}}.tar.gz" dest="/usr/local/nodejs" copy=no
+  unarchive:
+    src :  "/tmp/node-v{{nodejs_version}}.tar.gz"
+    dest : "/usr/local/nodejs"
+    copy : no
 
 - name: node.js | binary | Update the symbolic link to the node.js install
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,10 @@
   ignore_errors: yes
   register: node_version
   changed_when: node_version.rc != 0 or node_version.stdout != "v{{ nodejs_version }}"
-  when: nodejs_install_method == "source"
+  when: nodejs_install_method == "source" or nodejs_install_method == "binary"
 
 - include: source.yml
   when: nodejs_install_method == "source" and node_version.changed
+
+- include: binary.yml
+  when: nodejs_install_method == "binary" and node_version.changed

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,52 +1,36 @@
 # file: nodejs/tasks/source.yml
 
-- name: node.js | Make sure that the directory to hold the node.js binaries exists
+- name: node.js | source | Make sure that the directory to hold the node.js binaries exists
   file:
-    path: /usr/local/nodejs
+    path: "{{nodejs_directory}}"
     state: directory
     recurse: yes
     mode: 0755
 
-- name: node.js | Download the node.js source
+- name: node.js | source | Download the node.js source
   get_url:
     url: "{{nodejs_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: node.js | Unpack the node.js source
+- name: node.js | source | Unpack the node.js source
   shell: tar -xvzf /tmp/node-v{{nodejs_version}}.tar.gz chdir=/tmp creates=/tmp/node-v{{nodejs_version}}
 
-- name: node.js | Get the number of processors
+- name: node.js | source |Get the number of processors
   command: nproc
   register: cpu_count
 
-- name: node.js | Build node.js from source
+- name: node.js | source | Build node.js from source
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&
-    ./configure --prefix={{nodejs_prefix}} &&
+    ./configure --prefix={{nodejs_source_prefix}} &&
     make -j {{cpu_count.stdout}} &&
     sudo make install
 
-- name: node.js | Update the symbolic link to the node.js install
+- name: node.js | source | Update the symbolic link to the node.js install
   file:
-    path: /usr/local/nodejs/default
-    src: "{{nodejs_prefix}}"
+    path: "{{nodejs_directory}}/default"
+    src: "{{nodejs_source_prefix}}"
     state: link
     force: yes
 
-- name: node.js | Add the node.js binary to the system path
-  lineinfile: "dest={{item.dest}} regexp={{item.regexp}} line={{item.line}} state={{item.state}}"
-  with_items:
-    - { dest: "/etc/profile", regexp: "^NODE_HOME=/usr/local/nodejs/default", line: "NODE_HOME=/usr/local/nodejs/default", state: "present" }
-    - { dest: "/etc/profile", regexp: "^PATH=.*NODE_HOME.*", line: "PATH=$PATH:$NODE_HOME/bin", state: "present" }
-
-- name: node.js | Inform the system where node is located and set this one as the default
-  shell: "{{item}}"
-  with_items:
-    - 'update-alternatives --install "/usr/bin/node" "node" "/usr/local/nodejs/default/bin/node" 1'
-    - 'update-alternatives --set node /usr/local/nodejs/default/bin/node'
-
-- name: node.js | Inform the system where npm is located and set this one as the default
-  shell: "{{item}}"
-  with_items:
-    - 'update-alternatives --install "/usr/bin/npm" "npm" "/usr/local/nodejs/default/bin/npm" 1'
-    - 'update-alternatives --set npm /usr/local/nodejs/default/bin/npm'
+- include: update_path.yml

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -9,7 +9,7 @@
 
 - name: node.js | source | Download the node.js source
   get_url:
-    url: "{{nodejs_url}}"
+    url: "{{nodejs_source_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
 - name: node.js | source | Unpack the node.js source

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -1,0 +1,20 @@
+# file: nodejs/tasks/update_path.yml
+
+- name: node.js | update_path | Add the node.js binary to the system path
+  lineinfile: "dest={{item.dest}} regexp={{item.regexp}} line={{item.line}} state={{item.state}}"
+  with_items:
+    - { dest: "/etc/profile", regexp: "^NODE_HOME=/usr/local/nodejs/default", line: "NODE_HOME=/usr/local/nodejs/default", state: "present" }
+    - { dest: "/etc/profile", regexp: "^PATH=.*NODE_HOME.*", line: "PATH=$PATH:$NODE_HOME/bin", state: "present" }
+
+- name: node.js | update_path | Inform the system where node is located and set this one as the default
+  shell: "{{item}}"
+  with_items:
+    - 'update-alternatives --install "/usr/bin/node" "node" "/usr/local/nodejs/default/bin/node" 1'
+    - 'update-alternatives --set node /usr/local/nodejs/default/bin/node'
+
+- name: node.js | update_path | Inform the system where npm is located and set this one as the default
+  shell: "{{item}}"
+  with_items:
+    - 'update-alternatives --install "/usr/bin/npm" "npm" "/usr/local/nodejs/default/bin/npm" 1'
+    - 'update-alternatives --set npm /usr/local/nodejs/default/bin/npm'
+

--- a/test.yml
+++ b/test.yml
@@ -1,4 +1,6 @@
+---
 - hosts: all
+  sudo: True
   vars_files:
     - 'defaults/main.yml'
   tasks:


### PR DESCRIPTION
Hi,

I had the requirement that I need to install node v0.11.*, but compiling from source is a bit slow, therefore I implemented a third "binary" way to install nodejs - by downloading the precompiled version.

I tested the source and binary installs on a fresh ubuntu vagrant machine, there things worked as expected. 

I'm still a little new to the world of ansible so if you have any comments or want me to change things I'm happy for feedback also.