### PR TITLE
Replace Ansibles with ANXS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## Ansibles - nodejs [![Build Status](https://travis-ci.org/Ansibles/nodejs.png)](https://travis-ci.org/Ansibles/nodejs)
+## ANXS - nodejs [![Build Status](https://travis-ci.org/ANXS/nodejs.png)](https://travis-ci.org/ANXS/nodejs)
 
 Ansible role for installing nodejs, from package or by building it from source.
 
 
 #### Requirements & Dependencies
 - Tested on Ansible 1.4 or higher.
-- Depends on Ansibles.build-essential
+- Depends on ANXS.build-essential
 
 
 #### Variables
@@ -26,4 +26,4 @@ Licensed under the MIT License. See the LICENSE file for details.
 
 #### Feedback, bug-reports, requests, ...
 
-Are [welcome](https://github.com/ansibles/nodejs/issues)!
+Are [welcome](https://github.com/ANXS/nodejs/issues)!

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 
 galaxy_info:
   author: pjan vandaele
-  company: Ansibles
+  company: ANXS
   description: "Install nodejs, from package or build from source"
   min_ansible_version: 1.4
   license: MIT
@@ -15,5 +15,5 @@ galaxy_info:
   - development
 
 dependencies:
-  - role: Ansibles.build-essential
+  - role: ANXS.build-essential
     when: nodejs_install_method is defined and nodejs_install_method == "source"


### PR DESCRIPTION
Replace all occurrences of Ansibles with ANXS.
This should make things more coherent between ANXS packages.