### PR TITLE
install packages erquired for building from source

### DIFF
--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,5 +1,12 @@
 # file: nodejs/tasks/source.yml
 
+- name: node.js | source | get packages required to compile from source
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - build-essential
+
 - name: node.js | source | Make sure that the directory to hold the node.js binaries exists
   file:
     path: "{{nodejs_directory}}"


### PR DESCRIPTION
@otakup0pe 
I got an error on a blank precise64 machine when trying to build from source.
```
flock: g++: No such file or directory
```
so I added a step do install packages required for building form source