### PR TITLE
Alternatives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
 install:
-  - pip install ansible==1.6.9
+  - pip install ansible==1.8.4
 script:
   - echo localhost > inventory
   - mkdir -p ~/roles/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ install:
   - pip install ansible==1.6.9
 script:
   - echo localhost > inventory
+  - mkdir -p ~/roles/
+  - ansible-galaxy install -r requirements.yml
   - ansible-playbook -i inventory -e nodejs_install_method=binary test.yml --syntax-check
   - ansible-playbook -i inventory -e nodejs_install_method=binary test.yml --connection=local --sudo
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
 install:
-  - pip install ansible==1.5.0
+  - pip install ansible==1.6.9
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory -e nodejs_install_method=binary test.yml --syntax-check

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ~/roles/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+- src: ANXS.build-essential
+  version: master
+

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -34,3 +34,4 @@
     force: yes
 
 - include: update_path.yml
+

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -1,20 +1,25 @@
 # file: nodejs/tasks/update_path.yml
 
-- name: node.js | update_path | Add the node.js binary to the system path
-  lineinfile: "dest={{item.dest}} regexp={{item.regexp}} line={{item.line}} state={{item.state}}"
-  with_items:
-    - { dest: "/etc/profile", regexp: "^NODE_HOME=/usr/local/nodejs/default", line: "NODE_HOME=/usr/local/nodejs/default", state: "present" }
-    - { dest: "/etc/profile", regexp: "^PATH=.*NODE_HOME.*", line: "PATH=$PATH:$NODE_HOME/bin", state: "present" }
+- name: node.js | Add the node installation path to the system path
+  lineinfile:
+    dest: /etc/profile
+    regexp: '^NODE_HOME={{ nodejs_directory }}/default'
+    line: 'NODE_HOME={{ nodejs_directory }}/default'
+    state: present
 
-- name: node.js | update_path | Inform the system where node is located and set this one as the default
-  shell: "{{item}}"
-  with_items:
-    - 'update-alternatives --install "/usr/bin/node" "node" "/usr/local/nodejs/default/bin/node" 1'
-    - 'update-alternatives --set node /usr/local/nodejs/default/bin/node'
+- name: mode.js | Add the node binary path to the system path
+  lineinfile:
+    dest: /etc/profile
+    regexp: '^PATH=.*NODE_HOME.*'
+    line: 'PATH=$PATH:$NODE_HOME/bin'
+    state: present
 
-- name: node.js | update_path | Inform the system where npm is located and set this one as the default
-  shell: "{{item}}"
+- name: node.js | Inform the system where the binaries are located and set as the default
+  alternatives:
+    name: "{{ item }}"
+    path: "{{ nodejs_directory }}/default/bin/{{ item }}"
+    link: "/usr/bin/{{ item }}"
   with_items:
-    - 'update-alternatives --install "/usr/bin/npm" "npm" "/usr/local/nodejs/default/bin/npm" 1'
-    - 'update-alternatives --set npm /usr/local/nodejs/default/bin/npm'
+    - node
+    - npm
 

--- a/test.yml
+++ b/test.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
-  sudo: True
-  vars_files:
-    - 'defaults/main.yml'
-  tasks:
-    - include: 'tasks/main.yml'
+  sudo: yes
+
+  roles:
+    - .
+


### PR DESCRIPTION
Hello again,

This is a new PR for adding nodejs and npm to our system's PATH using Ansible's alternatives module.
Also, nodejs doesn't build from source if `build-essential` is not installed, so I've added that to `tasks/source.yml`.

This has been tested using the provided Vagrantfile.

Thank you.