### PR TITLE
Set https for downloading packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,9 @@ nodejs_install_method     : "source"
 nodejs_version            : "0.10.26"
 
 nodejs_directory          : "/usr/local/nodejs"
-nodejs_source_url         : "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
+nodejs_source_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
 nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
 
 # possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
-nodejs_binary_url         : "http://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
+nodejs_binary_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
 nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}"


### PR DESCRIPTION
Seems downloading via HTTP from nodejs.org/dist don't work now. So installation process fails.