### PR TITLE
only maybe handle system paths, allowing installation as non-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
-.DS_Store
-.AppleDouble
-.LSOverride
-Icon
-._*
-.Spotlight-V100
-.Trashes
-.vagrant
-test
+test.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 install:
   - sudo apt-get update -qq
   - sudo apt-get install python-apt python-pycurl
-  - pip install ansible urllib3
+  - pip install ansible urllib3 pyOpenSSL pyasn1 ndg-httpsclient
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   # Play test
   - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
   # Idempotence test
-  - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" > idempotence_out
+  - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
+  - echo "what now"
   - sudo apt-get install python-apt
   - pip install -U ansible python-pycurl
   # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python: "2.7"
-dist: ubuntu1604 # apt-key no longer works on 1404
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 install:
   - sudo apt-get update -qq
   - sudo apt-get install python-apt python-pycurl
-  - pip install ansible
+  - pip install ansible urllib3
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - pip install -U ansible
+  - pip install -U ansible urllib3
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ script:
   - echo localhost > inventory
 
   # Syntax check
-  - ansible-playbook -i inventory tests/playbook.yml --syntax-check
+  - ansible-playbook -i inventory test.yml --syntax-check
 
   # Play test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS"
+  - travis_wait ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS"
 
   # Idempotence test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
+  - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: python
 python: "2.7"
-group: "edge" # https://github.com/travis-ci/travis-ci/issues/8048
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
@@ -14,7 +13,7 @@ install:
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:
-  - source ~/virtualenv/python2.7/bin/activate
+  - which python ; which pip ; which ansible-playbook
   - echo localhost > inventory
 
   # Syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
   - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
+  - ls -R /usr/local/nodejs || true
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
 
   # Play test
-  - travis_wait ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS"
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
 
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   # Syntax check
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
   # Idempotence test
-  - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" > idempotence_out
+  - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - pip install -U ansible urllib3
+  - pip install -U ansible
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:
+  - source ~/virtualenv/python2.7/bin/activate
   - echo localhost > inventory
 
   # Syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   # Syntax check
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`"
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 ---
 language: python
 python: "2.7"
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
 env:
   - ROLE_OPTIONS="nodejs_install_method=source"
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - pip install -U ansible
+  - pip install -U ansible python-apt python-pycurl
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: python
 python: "2.7"
+group: "edge" # https://github.com/travis-ci/travis-ci/issues/8048
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   # Syntax check
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
-  - travis_wait 30 /home/travis/virtualenv/python2.7.14/bin/ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
   # Idempotence test
-  - /home/travis/virtualenv/python2.7.14/bin/ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
+  - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - echo "what now"
   - sudo apt-get install python-apt
-  - pip install -U ansible python-pycurl
+  - pip install -U ansible pycurl
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,23 @@
 ---
 language: python
 python: "2.7"
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
+virtualenv:
+  system_site_packages: true
 env:
   - ROLE_OPTIONS="nodejs_install_method=source"
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - pip install -U ansible
-  # Install dependencies
+  - sudo apt-get update -qq
+  - sudo apt-get install python-apt python-pycurl
+  - pip install -U ansible urllib3 pyOpenSSL pyasn1 ndg-httpsclient
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory
-
   # Syntax check
-  - ansible-playbook -i inventory tests/playbook.yml --syntax-check
-
+  - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS"
-
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`"
   # Idempotence test
-  - ansible-playbook -i inventory tests/playbook.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
+  - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
   - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
-  - ls -R /usr/local/nodejs || true
+  - ls -R /usr/local || true
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
   - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
-  - ls -R /usr/local || true
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --become -e "$ROLE_OPTIONS" -e "ansible_python_interpreter=`which python`" | tee idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: python
 python: "2.7"
+distro: ubuntu1604 # apt-key no longer works on 1404
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
@@ -13,7 +14,6 @@ install:
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:
-  - which python ; which pip ; which ansible-playbook
   - echo localhost > inventory
 
   # Syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
 
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which pyton`"
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
 
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,15 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - sudo apt-get install python-apt
-  - pip install -U ansible pycurl
-  # Install dependencies
+  - sudo apt-get update -qq
+  - sudo apt-get install python-apt python-pycurl
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory
-
   # Syntax check
   - ansible-playbook -i inventory test.yml --syntax-check
-
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which python`"
-
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install python-apt python-pycurl
+  - sudo apt-get install python-apt python-pycurl ansible
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
 python: "2.7"
+virtualenv:
+  system_site_packages: true
 env:
   - ROLE_OPTIONS="nodejs_install_method=source"
   - ROLE_OPTIONS="nodejs_install_method=package"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=package"
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
-  - pip install -U ansible python-apt python-pycurl
+  - sudo apt-get install python-apt
+  - pip install -U ansible python-pycurl
   # Install dependencies
   - ansible-galaxy install -r tests/requirements.yml
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
   - ROLE_OPTIONS="nodejs_install_method=binary"
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install python-apt python-pycurl ansible
+  - sudo apt-get install python-apt python-pycurl
+  - pip install ansible
   - ansible-galaxy install -r tests/requirements.yml
 script:
   - echo localhost > inventory

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python: "2.7"
-distro: ubuntu1604 # apt-key no longer works on 1404
+dist: ubuntu1604 # apt-key no longer works on 1404
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - ansible-playbook -i inventory test.yml --syntax-check
 
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
+  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv -e "ansible_python_interpreter=`which pyton`"
 
   # Idempotence test
   - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   # Syntax check
   - ansible-playbook -i inventory test.yml --syntax-check
   # Play test
-  - travis_wait 30 ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
+  - travis_wait 30 /home/travis/virtualenv/python2.7.14/bin/ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" -vvv
   # Idempotence test
-  - ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
+  - /home/travis/virtualenv/python2.7.14/bin/ansible-playbook -i inventory test.yml --connection=local --sudo -e "$ROLE_OPTIONS" > idempotence_out
   - ./tests/idempotence_check.sh idempotence_out

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role for installing nodejs, from package or by building it from source.
 
 
 #### Requirements & Dependencies
-- Tested on Ansible 1.4 or higher.
+- Tested on Ansible 2.3.2 or higher.
 - Depends on ANXS.build-essential when using install_method of "source"
 
 #### Variables

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,18 +9,13 @@ Vagrant.configure('2') do |config|
   config.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
 
   config.vm.define 'anxs' do |machine|
-    machine.vm.box = "ubuntu/trusty64"
-    #machine.vm.box = "ubuntu/precise64"
-    #machine.vm.box = "debian/jessie64"
-    #machine.vm.box = "debian/wheezy64"
-    #machine.vm.box = "chef/centos-7.1"
-    #machine.vm.box = "chef/centos-6.6"
+    machine.vm.box = "hashicorp/trusty64"
 
     machine.vm.network :private_network, ip: '192.168.88.17'
     machine.vm.hostname = 'anxs.local'
     machine.vm.provision 'ansible' do |ansible|
-      ansible.playbook = 'tests/playbook.yml'
-      ansible.sudo = true
+      ansible.playbook = 'test.yml'
+      ansible.become = true
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
       ansible.extra_vars = {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,10 @@
-# file: nodejs/defaults/main.yml
-
+---
 nodejs_arch: "{{ansible_architecture}}"
-nodejs_install_method     : "source"
-nodejs_version            : "9.5.0"
-
-nodejs_directory          : "/usr/local/nodejs"
-nodejs_source_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
-nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
-
+nodejs_install_method: "source"
+nodejs_version: "9.5.0"
+nodejs_directory: "/usr/local/nodejs"
+nodejs_source_url: "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
+nodejs_source_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}"
 # possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
-nodejs_binary_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
-
+nodejs_binary_url: "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
 nodejs_system_paths: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
 # possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
 nodejs_binary_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
 nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}"
+
+nodejs_system_paths: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,5 @@ nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
 
 # possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
 nodejs_binary_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
-nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}"
 
 nodejs_system_paths: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # file: nodejs/defaults/main.yml
 
 nodejs_install_method     : "source"
-nodejs_version            : "0.10.44"
+nodejs_version            : "9.5.0"
 
 nodejs_directory          : "/usr/local/nodejs"
 nodejs_source_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 # file: nodejs/defaults/main.yml
 
+nodejs_arch: "{{ansible_architecture}}"
 nodejs_install_method     : "source"
 nodejs_version            : "9.5.0"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,10 @@
-# file: nodejs/defaults/main.yml
-
-nodejs_install_method     : "source"
-nodejs_version            : "0.10.44"
-
-nodejs_directory          : "/usr/local/nodejs"
-nodejs_source_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
-nodejs_source_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
-
+---
+nodejs_arch: "{{ansible_architecture}}"
+nodejs_install_method: "source"
+nodejs_version: "9.5.0"
+nodejs_directory: "/usr/local/nodejs"
+nodejs_source_url: "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}.tar.gz"
+nodejs_source_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}"
 # possible achitectures: darwin-x64, darwin-x86, linux-x64, linux-x86, sunos-x64, sunos-x86
-nodejs_binary_url         : "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
-nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}"
-
+nodejs_binary_url: "https://nodejs.org/dist/v{{nodejs_version}}/node-v{{nodejs_version}}-{{ansible_system | lower}}-x{{ansible_userspace_bits |replace('32', '86')}}.tar.gz"
 nodejs_system_paths: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Install nodejs, from package, build from source or download binary tarball"
-  min_ansible_version: 1.4
+  min_ansible_version: 2.3.2
   license: MIT
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,4 @@
-# file: xxx/meta/main.yml
-
+---
 galaxy_info:
   author: pjan vandaele
   company: ANXS

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,9 @@
-# file: xxx/meta/main.yml
-
+---
 galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Install nodejs, from package, build from source or download binary tarball"
-  min_ansible_version: 1.4
+  min_ansible_version: 2.3.2
   license: MIT
   platforms:
   - name: Ubuntu
@@ -16,4 +15,7 @@ galaxy_info:
 
 dependencies:
   - role: ANXS.build-essential
-    when: nodejs_install_method is defined and nodejs_install_method == "source"
+    when: >
+      nodejs_install_method is defined and
+      nodejs_install_method == "source" and
+      ansible_os_family == 'Debian'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,7 @@ galaxy_info:
 
 dependencies:
   - role: ANXS.build-essential
-    when: nodejs_install_method is defined and nodejs_install_method == "source"
+    when: >
+      nodejs_install_method is defined and
+      nodejs_install_method == "source" and
+      ansible_os_family == 'Debian'

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -1,12 +1,5 @@
 # file: nodejs/tasks/binary.yml
 
-- name: node.js | binary | Make sure that the directory to hold the node.js binaries exists
-  file:
-    path: "{{nodejs_binary_prefix}}"
-    state: directory
-    recurse: yes
-    mode: 0755
-
 - name: node.js | binary | Download the node.js binary for your distribution
   get_url:
     url: "{{nodejs_binary_url}}"

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -1,22 +1,21 @@
-# file: nodejs/tasks/binary.yml
-
-- name: Download the node.js binary for your distribution
+---
+- name: "Download the node.js binary for your distribution"
   get_url:
     url: "{{nodejs_binary_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: Create node.js directory
+- name: "Create node.js directory"
   file:
     path: "/usr/local/nodejs"
     state: directory
     
-- name: Unpack the node.js package
+- name: "Unpack the node.js package"
   unarchive:
     src :  "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest : "/usr/local/nodejs"
     copy : no
 
-- name: Update the symbolic link to the node.js install
+- name: "Update the symbolic link to the node.js install"
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_binary_prefix}}"

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -1,17 +1,22 @@
 # file: nodejs/tasks/binary.yml
 
-- name: node.js | binary | Download the node.js binary for your distribution
+- name: Download the node.js binary for your distribution
   get_url:
     url: "{{nodejs_binary_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: node.js | binary | Unpack the node.js package
+- name: Create node.js directory
+  file:
+    path: "/usr/local/nodejs"
+    state: directory
+    
+- name: Unpack the node.js package
   unarchive:
     src :  "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest : "/usr/local/nodejs"
     copy : no
 
-- name: node.js | binary | Update the symbolic link to the node.js install
+- name: Update the symbolic link to the node.js install
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_binary_prefix}}"

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -1,28 +1,25 @@
-# file: nodejs/tasks/binary.yml
-
-- name: node.js | binary | Make sure that the directory to hold the node.js binaries exists
-  file:
-    path: "{{nodejs_binary_prefix}}"
-    state: directory
-    recurse: yes
-    mode: 0755
-
-- name: node.js | binary | Download the node.js binary for your distribution
+---
+- name: "Download the node.js binary for your distribution"
   get_url:
     url: "{{nodejs_binary_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: node.js | binary | Unpack the node.js package
+- name: "Create node.js directory"
+  file:
+    path: "/usr/local/nodejs"
+    state: "directory"
+    
+- name: "Unpack the node.js package"
   unarchive:
     src :  "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest : "/usr/local/nodejs"
     copy : no
 
-- name: node.js | binary | Update the symbolic link to the node.js install
+- name: "Update the symbolic link to the node.js install"
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_binary_prefix}}"
-    state: link
+    state: "link"
     force: yes
 
 - include: update_path.yml

--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -7,7 +7,7 @@
 - name: "Create node.js directory"
   file:
     path: "/usr/local/nodejs"
-    state: directory
+    state: "directory"
     
 - name: "Unpack the node.js package"
   unarchive:
@@ -19,7 +19,7 @@
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_binary_prefix}}"
-    state: link
+    state: "link"
     force: yes
 
 - include: update_path.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,10 @@
   when: nodejs_install_method == "package"
 
 - name: node.js | Check if the node version is already installed
-  command: node --version
+  command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
   register: node_version
-  changed_when: node_version.rc != 0 or node_version.stdout != "v{{ nodejs_version }}"
+  changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "source" or nodejs_install_method == "binary"
 
 - include: source.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,21 @@
-# file: nodejs/tasks/main.yml
-
+---
 - include: package.yml
   when: nodejs_install_method == "package"
-
-- name: node.js | Check if the node version is already installed
+- name: Check if the node version is already installed
+  command: "{{nodejs_binary_prefix}}/bin/node --version"
+  ignore_errors: yes
+  failed_when: no
+  register: nodejs_binary_version
+  changed_when: nodejs_binary_version.rc != 0 or nodejs_binary_version.stdout.find(nodejs_version) < 0
+  when: nodejs_install_method == "binary"
+- name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
-  register: node_version
-  changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
-  when: nodejs_install_method == "source" or nodejs_install_method == "binary"
-
+  failed_when: no  
+  register: nodejs_source_version
+  changed_when: nodejs_source_version.rc != 0 or nodejs_source_version.stdout.find(nodejs_version) < 0
+  when: nodejs_install_method == "source"
 - include: source.yml
-  when: nodejs_install_method == "source" and node_version.changed
-
+  when: nodejs_install_method == "source" and nodejs_source_version.changed
 - include: binary.yml
-  when: nodejs_install_method == "binary" and node_version.changed
+  when: nodejs_install_method == "binary" and nodejs_binary_version.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,21 +5,17 @@
   command: "{{nodejs_binary_prefix}}/bin/node --version"
   ignore_errors: yes
   failed_when: no
-  register: nodejs_current_version
-  changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
+  register: nodejs_binary_version
+  changed_when: nodejs_binary_version.rc != 0 or nodejs_binary_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "binary"
 - name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
   failed_when: no  
-  register: nodejs_current_version
-  changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
+  register: nodejs_source_version
+  changed_when: nodejs_source_version.rc != 0 or nodejs_source_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "source"
 - include: source.yml
-  when: nodejs_install_method == "source" and nodejs_current_version.changed
-- debug:
-    var: nodejs_current_version
-- debug:
-    var: nodejs_install_method
+  when: nodejs_install_method == "source" and nodejs_source_version.changed
 - include: binary.yml
-  when: nodejs_install_method == "binary" and nodejs_current_version.changed
+  when: nodejs_install_method == "binary" and nodejs_binary_version.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,6 @@
-# file: nodejs/tasks/main.yml
-
+---
 - include: package.yml
   when: nodejs_install_method == "package"
-
 - name: Check if the node version is already installed
   command: "{{nodejs_binary_prefix}}/bin/node --version"
   ignore_errors: yes
@@ -10,7 +8,6 @@
   register: nodejs_current_version
   changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "binary"
-
 - name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
@@ -18,9 +15,7 @@
   register: nodejs_current_version
   changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "source"
-
 - include: source.yml
   when: nodejs_install_method == "source" and nodejs_current_version.changed
-
 - include: binary.yml
   when: nodejs_install_method == "binary" and nodejs_current_version.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
 - name: Check if the node version is already installed
   command: "{{nodejs_binary_prefix}}/bin/node --version"
   ignore_errors: yes
+  failed_when: no
   register: nodejs_current_version
   changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "binary"
@@ -13,6 +14,7 @@
 - name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
+  failed_when: no  
   register: nodejs_current_version
   changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "source"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - include: package.yml
   when: nodejs_install_method == "package"
 
-- name: node.js | Check if the node version is already installed
+- name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
   register: node_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,18 @@
   when: nodejs_install_method == "package"
 
 - name: Check if the node version is already installed
+  command: "{{nodejs_binary_prefix}}/bin/node --version"
+  ignore_errors: yes
+  register: node_version
+  changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
+  when: nodejs_install_method == "binary"
+
+- name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
   register: node_version
   changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
-  when: nodejs_install_method == "source" or nodejs_install_method == "binary"
+  when: nodejs_install_method == "source"
 
 - include: source.yml
   when: nodejs_install_method == "source" and node_version.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,19 +6,19 @@
 - name: Check if the node version is already installed
   command: "{{nodejs_binary_prefix}}/bin/node --version"
   ignore_errors: yes
-  register: node_version
-  changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
+  register: nodejs_current_version
+  changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "binary"
 
 - name: Check if the node version is already installed
   command: "{{nodejs_directory}}/node-v{{nodejs_version}}/bin/node --version"
   ignore_errors: yes
-  register: node_version
-  changed_when: node_version.rc != 0 or node_version.stdout.find(nodejs_version) < 0
+  register: nodejs_current_version
+  changed_when: nodejs_current_version.rc != 0 or nodejs_current_version.stdout.find(nodejs_version) < 0
   when: nodejs_install_method == "source"
 
 - include: source.yml
-  when: nodejs_install_method == "source" and node_version.changed
+  when: nodejs_install_method == "source" and nodejs_current_version.changed
 
 - include: binary.yml
-  when: nodejs_install_method == "binary" and node_version.changed
+  when: nodejs_install_method == "binary" and nodejs_current_version.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,9 @@
   when: nodejs_install_method == "source"
 - include: source.yml
   when: nodejs_install_method == "source" and nodejs_current_version.changed
+- debug:
+    var: nodejs_current_version
+- debug:
+    var: nodejs_install_method
 - include: binary.yml
   when: nodejs_install_method == "binary" and nodejs_current_version.changed

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -23,6 +23,6 @@
 
 - name: node.js | Install the node.js package
   apt:
-    pkg: "nodejs={{ nodejs_version }}-1nodesource1~{{ ansible_lsb.codename }}1"
+    deb: "{{nodejs_apt_url}}"
     update_cache: yes
     state: present

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,27 +1,32 @@
 # file: nodejs/tasks/package.yml
 
-- name: Make sure the ansible required dependencies are installed
+- name: "Make sure the ansible required dependencies are installed"
   apt:
     pkg: python-pycurl
     state: present
 
-- name: add signing key
+- name: "add signing key"
   apt_key:
     url: "{{nodejs_apt_key_url}}"
     id: "{{nodejs_apt_key}}"
     state: present
 
-- name: add sources.list entry
+- name: "Set amd64 arch"
+  set_fact:
+    nodejs_arch: "amd64"
+  when: ansible_architecture == "x86_64"
+
+- name: "add sources.list entry"
   lineinfile:
     dest: /etc/apt/sources.list.d/nodesource.list
     create: yes
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
-    - "deb-src https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
+    - "deb https://deb.nodesource.com/node {{nodejs_arch}} main"
+    - "deb-src https://deb.nodesource.com/node {{nodejs_arch}} main"
 
-- name: Install the node.js package
+- name: "Install the node.js package"
   apt:
     deb: "{{nodejs_apt_url}}"
     update_cache: yes

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,17 +1,17 @@
 # file: nodejs/tasks/package.yml
 
-- name: node.js | Make sure the ansible required dependencies are installed
+- name: Make sure the ansible required dependencies are installed
   apt:
     pkg: python-pycurl
     state: present
 
-- name: node.js | add signing key
+- name: add signing key
   apt_key:
     url: "{{nodejs_apt_key_url}}"
     id: "{{nodejs_apt_key}}"
     state: present
 
-- name: node.js | add sources.list entry
+- name: add sources.list entry
   lineinfile:
     dest: /etc/apt/sources.list.d/nodesource.list
     create: yes
@@ -21,7 +21,7 @@
     - "deb https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
     - "deb-src https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
 
-- name: node.js | Install the node.js package
+- name: Install the node.js package
   apt:
     deb: "{{nodejs_apt_url}}"
     update_cache: yes

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -3,13 +3,11 @@
   apt:
     pkg: python-pycurl
     state: present
-
 - name: "add signing key"
   apt_key:
     url: "{{nodejs_apt_key_url}}"
     id: "{{nodejs_apt_key}}"
     state: present
-
 - name: "add sources.list entry"
   lineinfile:
     dest: /etc/apt/sources.list.d/nodesource.list
@@ -19,7 +17,6 @@
   with_items:
     - "deb {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
     - "deb-src {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
-
 - name: "Install the node.js package"
   apt:
     package: "nodejs"

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -22,8 +22,8 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/{{node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
-    - "deb-src https://deb.nodesource.com/{{node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
+    - "deb https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
+    - "deb-src https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -22,8 +22,8 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/{{nodejs_vsn}} {{ansible_lsb.codename}} main"
-    - "deb-src https://deb.nodesource.com/{{nodejs_vsn}} {{ansible_lsb.codename}} main"
+    - "deb https://deb.nodesource.com/{{node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
+    - "deb-src https://deb.nodesource.com/{{node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -7,7 +7,8 @@
 
 - name: node.js | add signing key
   apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    url: "{{nodejs_apt_key_url}}"
+    id: "{{nodejs_apt_key}}"
     state: present
 
 - name: node.js | add sources.list entry

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,27 +1,24 @@
-# file: nodejs/tasks/package.yml
-
-- name: node.js | Make sure the ansible required dependencies are installed
+---
+- name: "Make sure the ansible required dependencies are installed"
   apt:
     pkg: python-pycurl
     state: present
-
-- name: node.js | add signing key
+- name: "add signing key"
   apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    url: "{{nodejs_apt_key_url}}"
+    id: "{{nodejs_apt_key}}"
     state: present
-
-- name: node.js | add sources.list entry
+- name: "add sources.list entry"
   lineinfile:
     dest: /etc/apt/sources.list.d/nodesource.list
     create: yes
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
-    - "deb-src https://deb.nodesource.com/node {{ ansible_lsb.codename }} main"
-
-- name: node.js | Install the node.js package
+    - "deb {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
+    - "deb-src {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
+- name: "Install the node.js package"
   apt:
-    pkg: "nodejs={{ nodejs_version }}-1nodesource1~{{ ansible_lsb.codename }}1"
+    package: "nodejs"
     update_cache: yes
     state: present

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -22,8 +22,8 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
-    - "deb-src https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x}} {{ansible_lsb.codename}} main"
+    - "deb https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x {{ansible_lsb.codename}} main"
+    - "deb-src https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -10,11 +10,6 @@
     id: "{{nodejs_apt_key}}"
     state: present
 
-- name: "Set amd64 arch"
-  set_fact:
-    nodejs_arch: "amd64"
-  when: ansible_architecture == "x86_64"
-
 - name: "add sources.list entry"
   lineinfile:
     dest: /etc/apt/sources.list.d/nodesource.list
@@ -22,8 +17,8 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x {{ansible_lsb.codename}} main"
-    - "deb-src https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x {{ansible_lsb.codename}} main"
+    - "deb {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
+    - "deb-src {{nodejs_apt_url}} {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -22,8 +22,8 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x {{ansible_lsb.codename}} main"
-    - "deb-src https://deb.nodesource.com/node_{{node_version|split('.')[0]}}.x {{ansible_lsb.codename}} main"
+    - "deb https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x {{ansible_lsb.codename}} main"
+    - "deb-src https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,5 +1,4 @@
-# file: nodejs/tasks/package.yml
-
+---
 - name: "Make sure the ansible required dependencies are installed"
   apt:
     pkg: python-pycurl
@@ -23,11 +22,11 @@
     line: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node {{nodejs_arch}} main"
-    - "deb-src https://deb.nodesource.com/node {{nodejs_arch}} main"
+    - "deb https://deb.nodesource.com/{{nodejs_vsn}} {{ansible_lsb.codename}} main"
+    - "deb-src https://deb.nodesource.com/{{nodejs_vsn}} {{ansible_lsb.codename}} main"
 
 - name: "Install the node.js package"
   apt:
-    deb: "{{nodejs_apt_url}}"
+    package: "nodejs"
     update_cache: yes
     state: present

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -27,7 +27,11 @@
   command: sysctl -n hw.ncpu
   register: cpu_count
   when: ansible_os_family == 'Darwin'
-  
+
+- name: "TEST PLEASE REMOVE"
+  debug:
+    var: cpu_count
+
 - name: node.js | source | Build node.js from source
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -18,19 +18,25 @@
     src: "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest: "/tmp"
 
-- name: node.js | source |Get the number of processors (Linux)
+- name: node.js | source | Get the number of processors (Linux)
   command: nproc
-  register: cpu_count
+  register: cpu_count_linux
   when: ansible_system == 'Linux'
 
-- name: node.js | source |Get the number of processors (Darwin)
+- name: node.js | source | Get the number of processors (Darwin)
   command: sysctl -n hw.ncpu
-  register: cpu_count
+  register: cpu_count_darwin
   when: ansible_os_family == 'Darwin'
 
-- name: "TEST PLEASE REMOVE"
-  debug:
-    var: cpu_count
+- name: node.js | source | Set number of processors (Linux)
+  set_fact:
+    cpu_count: "{{cpu_count_linux}}"
+  when: ansible_system == 'Linux'
+
+- name: node.js | source | Set number of processors (Darwin)
+  set_fact:
+    cpu_count: "{{cpu_count_darwin}}"
+  when: ansible_system == 'Darwin'
 
 - name: node.js | source | Build node.js from source
   shell: >

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,51 +1,51 @@
 # file: nodejs/tasks/source.yml
 
-- name: node.js | source | Make sure that the directory to hold the node.js binaries exists
+- name: Make sure that the directory to hold the node.js binaries exists
   file:
     path: "{{nodejs_directory}}"
     state: directory
     recurse: yes
     mode: 0755
 
-- name: node.js | source | Download the node.js source
+- name: Download the node.js source
   get_url:
     url: "{{nodejs_source_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: node.js | source | Unpack the node.js source
+- name: Unpack the node.js source
   unarchive:
     copy: no
     src: "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest: "/tmp"
 
-- name: node.js | source | Get the number of processors (Linux)
+- name: Get the number of processors (Linux)
   command: nproc
   register: cpu_count_linux
   when: ansible_system == 'Linux'
 
-- name: node.js | source | Get the number of processors (Darwin)
+- name: Get the number of processors (Darwin)
   command: sysctl -n hw.ncpu
   register: cpu_count_darwin
   when: ansible_os_family == 'Darwin'
 
-- name: node.js | source | Set number of processors (Linux)
+- name: Set number of processors (Linux)
   set_fact:
     cpu_count: "{{cpu_count_linux}}"
   when: ansible_system == 'Linux'
 
-- name: node.js | source | Set number of processors (Darwin)
+- name: Set number of processors (Darwin)
   set_fact:
     cpu_count: "{{cpu_count_darwin}}"
   when: ansible_system == 'Darwin'
 
-- name: node.js | source | Build node.js from source
+- name: Build node.js from source
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&
     ./configure --prefix={{nodejs_source_prefix}} &&
     make -j {{cpu_count.stdout}} &&
     make install
 
-- name: node.js | source | Update the symbolic link to the node.js install
+- name: Update the symbolic link to the node.js install
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_source_prefix}}"

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,51 +1,59 @@
-# file: nodejs/tasks/source.yml
-
-- name: Make sure that the directory to hold the node.js binaries exists
+---
+- name: "Make sure that the directory to hold the node.js binaries exists"
   file:
     path: "{{nodejs_directory}}"
     state: directory
     recurse: yes
     mode: 0755
 
-- name: Download the node.js source
+- name: "Download the node.js source"
   get_url:
     url: "{{nodejs_source_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
 
-- name: Unpack the node.js source
+- name: "Unpack the node.js source"
   unarchive:
     copy: no
     src: "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest: "/tmp"
 
-- name: Get the number of processors (Linux)
+- name: "Get the number of processors (Linux)"
   command: nproc
   register: cpu_count_linux
   when: ansible_system == 'Linux'
+  changed: False
 
-- name: Get the number of processors (Darwin)
+- name: "Get the number of processors (Darwin)"
   command: sysctl -n hw.ncpu
   register: cpu_count_darwin
   when: ansible_os_family == 'Darwin'
+  changed: False
 
-- name: Set number of processors (Linux)
+- name: "Set number of processors (Linux)"
   set_fact:
     cpu_count: "{{cpu_count_linux}}"
   when: ansible_system == 'Linux'
+  changed: False
 
-- name: Set number of processors (Darwin)
+- name: "Set number of processors (Darwin)"
   set_fact:
     cpu_count: "{{cpu_count_darwin}}"
   when: ansible_system == 'Darwin'
 
-- name: Build node.js from source
+- name: "Check for artifact directory"
+  stat:
+    path: "/tmp/node-v{{nodejs_version}}/out/Release"
+  register: node_artifact_check
+
+- name: "Build node.js from source"
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&
     ./configure --prefix={{nodejs_source_prefix}} &&
     make -j {{cpu_count.stdout}} &&
     make install
+  when: not node_artifact_check.stat.exists
 
-- name: Update the symbolic link to the node.js install
+- name: "Update the symbolic link to the node.js install"
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_source_prefix}}"

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -27,7 +27,7 @@
     cd /tmp/node-v{{nodejs_version}} &&
     ./configure --prefix={{nodejs_source_prefix}} &&
     make -j {{cpu_count.stdout}} &&
-    sudo make install
+    make install
 
 - name: node.js | source | Update the symbolic link to the node.js install
   file:

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -21,19 +21,19 @@
   command: nproc
   register: cpu_count_linux
   when: ansible_system == 'Linux'
-  changed: False
+  changed_when: False
 
 - name: "Get the number of processors (Darwin)"
   command: sysctl -n hw.ncpu
   register: cpu_count_darwin
   when: ansible_os_family == 'Darwin'
-  changed: False
+  changed_when: False
 
 - name: "Set number of processors (Linux)"
   set_fact:
     cpu_count: "{{cpu_count_linux}}"
   when: ansible_system == 'Linux'
-  changed: False
+  changed_when: False
 
 - name: "Set number of processors (Darwin)"
   set_fact:

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,40 +1,54 @@
-# file: nodejs/tasks/source.yml
-
-- name: node.js | source | Make sure that the directory to hold the node.js binaries exists
+---
+- name: "Make sure that the directory to hold the node.js binaries exists"
   file:
     path: "{{nodejs_directory}}"
     state: directory
     recurse: yes
     mode: 0755
-
-- name: node.js | source | Download the node.js source
+- name: "Download the node.js source"
   get_url:
     url: "{{nodejs_source_url}}"
     dest: "/tmp/node-v{{nodejs_version}}.tar.gz"
-
-- name: node.js | source | Unpack the node.js source
+- name: "Unpack the node.js source"
   unarchive:
     copy: no
     src: "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest: "/tmp"
-
-- name: node.js | source |Get the number of processors
+- name: "Get the number of processors (Linux)"
   command: nproc
-  register: cpu_count
-
-- name: node.js | source | Build node.js from source
+  register: cpu_count_linux
+  when: ansible_system == 'Linux'
+  changed_when: False
+- name: "Get the number of processors (Darwin)"
+  command: sysctl -n hw.ncpu
+  register: cpu_count_darwin
+  when: ansible_os_family == 'Darwin'
+  changed_when: False
+- name: "Set number of processors (Linux)"
+  set_fact:
+    cpu_count: "{{cpu_count_linux}}"
+  when: ansible_system == 'Linux'
+  changed_when: False
+- name: "Set number of processors (Darwin)"
+  set_fact:
+    cpu_count: "{{cpu_count_darwin}}"
+  when: ansible_system == 'Darwin'
+- name: "Check for artifact directory"
+  stat:
+    path: "/tmp/node-v{{nodejs_version}}/out/Release"
+  register: node_artifact_check
+- name: "Build node.js from source"
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&
     ./configure --prefix={{nodejs_source_prefix}} &&
     make -j {{cpu_count.stdout}} &&
     make install
-
-- name: node.js | source | Update the symbolic link to the node.js install
+  when: not node_artifact_check.stat.exists
+- name: "Update the symbolic link to the node.js install"
   file:
     path: "{{nodejs_directory}}/default"
     src: "{{nodejs_source_prefix}}"
     state: link
     force: yes
-
 - include: update_path.yml
 

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -18,10 +18,16 @@
     src: "/tmp/node-v{{nodejs_version}}.tar.gz"
     dest: "/tmp"
 
-- name: node.js | source |Get the number of processors
+- name: node.js | source |Get the number of processors (Linux)
   command: nproc
   register: cpu_count
+  when: ansible_system == 'Linux'
 
+- name: node.js | source |Get the number of processors (Darwin)
+  command: sysctl -n hw.ncpu
+  register: cpu_count
+  when: ansible_os_family == 'Darwin'
+  
 - name: node.js | source | Build node.js from source
   shell: >
     cd /tmp/node-v{{nodejs_version}} &&

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -6,6 +6,7 @@
     regexp: '^NODE_HOME={{ nodejs_directory }}/default'
     line: 'NODE_HOME={{ nodejs_directory }}/default'
     state: present
+  when: nodejs_system_paths
 
 - name: mode.js | Add the node binary path to the system path
   lineinfile:
@@ -13,6 +14,7 @@
     regexp: '^PATH=.*NODE_HOME.*'
     line: 'PATH=$PATH:$NODE_HOME/bin'
     state: present
+  when: nodejs_system_paths
 
 - name: node.js | Inform the system where the binaries are located and set as the default
   alternatives:
@@ -22,4 +24,4 @@
   with_items:
     - node
     - npm
-
+  when: nodejs_system_paths

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -1,22 +1,19 @@
-# file: nodejs/tasks/update_path.yml
-
-- name: node.js | Add the node installation path to the system path
+---
+- name: "Add the node installation path to the system path"
   lineinfile:
     dest: /etc/profile
     regexp: '^NODE_HOME={{ nodejs_directory }}/default'
     line: 'NODE_HOME={{ nodejs_directory }}/default'
     state: present
   when: nodejs_system_paths
-
-- name: mode.js | Add the node binary path to the system path
+- name: "Add the node binary path to the system path"
   lineinfile:
     dest: /etc/profile
     regexp: '^PATH=.*NODE_HOME.*'
     line: 'PATH=$PATH:$NODE_HOME/bin'
     state: present
   when: nodejs_system_paths
-
-- name: node.js | Inform the system where the binaries are located and set as the default
+- name: "Inform the system where the binaries are located and set as the default"
   alternatives:
     name: "{{ item }}"
     path: "{{ nodejs_directory }}/default/bin/{{ item }}"

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -1,6 +1,5 @@
-# file: nodejs/tasks/update_path.yml
-
-- name: Add the node installation path to the system path
+---
+- name: "Add the node installation path to the system path"
   lineinfile:
     dest: /etc/profile
     regexp: '^NODE_HOME={{ nodejs_directory }}/default'
@@ -8,7 +7,7 @@
     state: present
   when: nodejs_system_paths
 
-- name: Add the node binary path to the system path
+- name: "Add the node binary path to the system path"
   lineinfile:
     dest: /etc/profile
     regexp: '^PATH=.*NODE_HOME.*'
@@ -16,7 +15,7 @@
     state: present
   when: nodejs_system_paths
 
-- name: Inform the system where the binaries are located and set as the default
+- name: "Inform the system where the binaries are located and set as the default"
   alternatives:
     name: "{{ item }}"
     path: "{{ nodejs_directory }}/default/bin/{{ item }}"

--- a/tasks/update_path.yml
+++ b/tasks/update_path.yml
@@ -1,6 +1,6 @@
 # file: nodejs/tasks/update_path.yml
 
-- name: node.js | Add the node installation path to the system path
+- name: Add the node installation path to the system path
   lineinfile:
     dest: /etc/profile
     regexp: '^NODE_HOME={{ nodejs_directory }}/default'
@@ -8,7 +8,7 @@
     state: present
   when: nodejs_system_paths
 
-- name: mode.js | Add the node binary path to the system path
+- name: Add the node binary path to the system path
   lineinfile:
     dest: /etc/profile
     regexp: '^PATH=.*NODE_HOME.*'
@@ -16,7 +16,7 @@
     state: present
   when: nodejs_system_paths
 
-- name: node.js | Inform the system where the binaries are located and set as the default
+- name: Inform the system where the binaries are located and set as the default
   alternatives:
     name: "{{ item }}"
     path: "{{ nodejs_directory }}/default/bin/{{ item }}"

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,12 @@
+---
+
+- hosts: all
+  remote_user: root
+  become: yes
+  vars_files:
+    - "defaults/main.yml"
+    - "vars/main.yml"
+  roles:
+    - 'ANXS.build-essential'
+  tasks:
+    - include: "tasks/main.yml"

--- a/test.yml
+++ b/test.yml
@@ -3,8 +3,6 @@
 - hosts: all
   remote_user: root
   become: yes
-  vars:
-    ansible_python_interpreter: "/usr/bin/env python"
   vars_files:
     - "defaults/main.yml"
     - "vars/main.yml"

--- a/test.yml
+++ b/test.yml
@@ -3,6 +3,8 @@
 - hosts: all
   remote_user: root
   become: yes
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
   vars_files:
     - "defaults/main.yml"
     - "vars/main.yml"

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,7 +1,0 @@
----
-
-- hosts: all
-  remote_user: root
-  become: yes
-  roles:
-    - role: nodejs

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,9 +1,0 @@
----
-
-- hosts: all
-  remote_user: root
-  become: yes
-  vars_files:
-    - ./vars.yml
-  roles:
-    - role: nodejs

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -3,7 +3,5 @@
 - hosts: all
   remote_user: root
   become: yes
-  vars_files:
-    - ./vars.yml
   roles:
     - role: nodejs

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,4 +1,0 @@
----
-
-nodejs_install_method     : "package"
-nodejs_version            : "0.10.44"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,6 @@
+---
+nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
+nodejs_apt_key: "68576280"
+nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
+nodejs_major_version: "{{nodejs_version.split('.')[0]}}"
+nodejs_apt_url: "https://deb.nodesource.com/node_{{nodejs_major_version}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,5 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
-nodejs_major_version: "{{(nodejs_version|split('.'))[0]}}"
+nodejs_major_version: "{{nodejs_version.split('.')[0]}}"
 nodejs_apt_url: "https://deb.nodesource.com/node_{{nodejs_major_version}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,5 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version.split('.')[0] }}.x/pool/main/n/nodejs/nodejs_{{nodejs_version}}-1nodesource1_{{ansible_lsb.codename}}.deb"
+
+nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
+nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version.split('.')[0] }}.x/pool/main/n/nodejs/nodejs_{{nodejs_version}}-1nodesource1_{{ansible_lsb.codename}}.deb"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,5 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
-nodejs_major_version: "{{nodejs_version|split('.')[0]}}"
+nodejs_major_version: "{{(nodejs_version|split('.'))[0]}}"
 nodejs_apt_url: "https://deb.nodesource.com/node_{{nodejs_major_version}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,5 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
-nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version|split('.')[0] }}.x"
+nodejs_major_version: "{{nodejs_version|split('.')[0]}}"
+nodejs_apt_url: "https://deb.nodesource.com/node_{{nodejs_major_version}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
+nodejs_apt_key: "68576280"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,4 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
+nodejs_apt_url: "https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,3 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
-nodejs_apt_vsn: "node_{{node_version|split('.')[0]}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,4 +2,4 @@
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
 nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
-nodejs_apt_url: "https://deb.nodesource.com/node_{{ node_version|split('.')[0] }}.x"
+nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version|split('.')[0] }}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280"
 nodejs_apt_key: "68576280"
-nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version.split('.')[0] }}.x/pool/main/n/nodejs/nodejs_{{nodejs_version}}-1nodesource1_{{ansible_lsb.codename}}.deb"
-
-nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
+nodejs_binary_prefix: "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"
+nodejs_apt_vsn: "node_{{node_version|split('.')[0]}}.x"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,4 +3,4 @@ nodejs_apt_key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=
 nodejs_apt_key: "68576280"
 nodejs_apt_url: "https://deb.nodesource.com/node_{{ nodejs_version.split('.')[0] }}.x/pool/main/n/nodejs/nodejs_{{nodejs_version}}-1nodesource1_{{ansible_lsb.codename}}.deb"
 
-nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}"
+nodejs_binary_prefix      : "{{nodejs_directory}}/node-v{{nodejs_version}}-{{ansible_system|lower}}-x{{ansible_userspace_bits|replace('32', '86')}}"


### PR DESCRIPTION
Note this will be a _breaking_ change (and version number will get bumped accordingly). This is because the `sudo` was removed from the `make install` and if you want this installed, via source, as root, you will need to specify `become: true` when invoking the playbook.